### PR TITLE
feat: add getConfig() and getScopeVariables() to Repl

### DIFF
--- a/tests/ReplTest.php
+++ b/tests/ReplTest.php
@@ -83,6 +83,8 @@ class ReplTest extends TestCase
         $expected = implode("\n", $lines);
 
         $input = new StringInput('');
+        $input->setInteractive(false);
+
         $output = Factory::createOutput();
         $helperSet = new HelperSet();
         $io = new ConsoleIO($input, $output, $helperSet);

--- a/tests/ReplTest.php
+++ b/tests/ReplTest.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 
 use function dirname;
-use function getenv;
 use function implode;
 use function phpversion;
 use function realpath;
@@ -69,12 +68,6 @@ class ReplTest extends TestCase
 
     public function testReplRun(): void
     {
-        if (getenv('GITHUB_ACTIONS') === 'true') {
-            $this->markTestSkipped(
-                'Skipping when running via GitHub Actions, due to a problem getting the command output.',
-            );
-        }
-
         $shellVersion = Shell::VERSION;
         $phpVersion = phpversion();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->

- Add public method `Repl::getConfig()`
- Add public method `Repl::getScopeVariables()`
- Add unit tests for 100% code coverage when running on GitHub Actions

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The `Repl` class did not have full coverage due to a problem running one of the test cases on GitHub Actions.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
